### PR TITLE
Maintenance

### DIFF
--- a/jflex-unicode-maven-plugin/pom.xml
+++ b/jflex-unicode-maven-plugin/pom.xml
@@ -47,8 +47,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/maven-jflex-plugin/pom.xml
+++ b/maven-jflex-plugin/pom.xml
@@ -81,8 +81,8 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/testsuite/jflex-testsuite-maven-plugin/pom.xml
+++ b/testsuite/jflex-testsuite-maven-plugin/pom.xml
@@ -77,11 +77,6 @@
       <artifactId>jflex</artifactId>
       <version>1.5.0-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>com.puppycrawl.tools</groupId>
-      <artifactId>checkstyle</artifactId>
-      <version>8.18</version>
-    </dependency>
   </dependencies>
   <scm>
     <connection>

--- a/testsuite/jflex-testsuite-maven-plugin/pom.xml
+++ b/testsuite/jflex-testsuite-maven-plugin/pom.xml
@@ -37,8 +37,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -78,17 +78,9 @@
       <version>1.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <!-- If this dependency is not included, the Ant Javac task can't find -->
-      <!-- the javac executable, because Maven automatically changes the     -->
-      <!-- JAVA_HOME environment variable/system property to point to the    -->
-      <!-- JRE rather than the JDK.  An alternative to including this dep.   -->
-      <!-- is setting the Ant Javac object to use forking,                   -->
-      <!-- i.e. "javac.setFork(true);").                                     -->
-      <groupId>sun.jdk</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.5.0</version>
-      <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      <groupId>com.puppycrawl.tools</groupId>
+      <artifactId>checkstyle</artifactId>
+      <version>8.18</version>
     </dependency>
   </dependencies>
   <scm>


### PR DESCRIPTION
Upon building (i.e. `mvn package`), I encountered two errors:

- "Source option 5 is no longer supported. Use 8 or later": [maven compiler archetype of 5 corresponding to Java SE 5 has been out of support since 2009](https://maven.apache.org/plugins/maven-compiler-plugin/)
- ~[`tools.jar` has been removed since Java 9](https://stackoverflow.com/a/55207956/1834787), `checkstyle` is a replacement~ package

To test:

```
docker run -v `pwd`:/root -it --rm -w /root maven sh -c "mvn package"
```